### PR TITLE
Build Cytomine and CytomineJob from CLI parameters

### DIFF
--- a/cytomine/cytomine.py
+++ b/cytomine/cytomine.py
@@ -181,11 +181,14 @@ class Cytomine(object):
         argparse: ArgumentParser
             The argument parser (same object as parameter)
         """
-        argparse.add_argument("--cytomine_host", dest="host", help="The Cytomine host (without protocol).", required=True)
-        argparse.add_argument("--cytomine_public_key", dest="public_key", help="The Cytomine public key.", required=True)
-        argparse.add_argument("--cytomine_private_key", dest="private_key", help="The Cytomine private key.", required=True)
-        argparse.add_argument("--cytomine_verbose", dest="verbose", type=int, default=logging.INFO,
-                              help="The verbosity level of the client.")
+        argparse.add_argument("--host", "--cytomine_host",
+                              dest="host", help="The Cytomine host (without protocol).", required=True)
+        argparse.add_argument("--publicKey", "--cytomine_public_key",
+                              dest="public_key", help="The Cytomine public key.", required=True)
+        argparse.add_argument("--privateKey", "--cytomine_private_key",
+                              dest="private_key", help="The Cytomine private key.", required=True)
+        argparse.add_argument("--verbose", "--cytomine_verbose",
+                              dest="verbose", type=int, default=logging.INFO, help="The verbosity level of the client.")
         return argparse
 
     def _start(self):

--- a/cytomine/cytomine.py
+++ b/cytomine/cytomine.py
@@ -19,6 +19,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from argparse import ArgumentParser
+
 __author__ = "Rubens Ulysse <urubens@uliege.be>"
 __contributors__ = ["Marée Raphaël <raphael.maree@uliege.be>", "Mormont Romain <r.mormont@uliege.be>"]
 __copyright__ = "Copyright 2010-2018 University of Liège, Belgium, http://www.cytomine.be/"
@@ -137,6 +139,54 @@ class Cytomine(object):
             A connected Cytomine client.
         """
         return cls(host, public_key, private_key, verbose, use_cache)
+
+    @classmethod
+    def connect_from_cli(cls, argv, use_cache=True):
+        """
+        Connect with data taken from a command line interface.
+
+        Parameters
+        ----------
+        argv: list
+            Command line parameters (executable name excluded)
+        use_cache : bool
+            True to use HTTP cache, False otherwise.
+
+        Returns
+        -------
+        client : Cytomine
+            A connected Cytomine client.
+
+        Notes
+        -----
+        If some parameters are invalid, the function stops the execution and displays an help.
+        """
+        argparse = cls._add_cytomine_cli_args(ArgumentParser())
+        params, _ = argparse.parse_known_args(args=argv)
+        return cls.connect(params.host, params.public_key, params.private_key, params.verbose, use_cache=use_cache)
+
+    @staticmethod
+    def _add_cytomine_cli_args(argparse):
+        """
+        Add cytomine CLI args to the ArgumentParser object: cytomine_host, cytomine_public_key, cytomine_private_key and
+        cytomine_verbose.
+
+        Parameters
+        ----------
+        argparse: ArgumentParser
+            The argument parser
+
+        Return
+        ------
+        argparse: ArgumentParser
+            The argument parser (same object as parameter)
+        """
+        argparse.add_argument("--cytomine_host", dest="host", help="The Cytomine host (without protocol).")
+        argparse.add_argument("--cytomine_public_key", dest="public_key", help="The Cytomine public key.")
+        argparse.add_argument("--cytomine_private_key", dest="private_key", help="The Cytomine private key.")
+        argparse.add_argument("--cytomine_verbose", dest="verbose", type=int, default=logging.INFO,
+                              help="The verbosity level of the client.")
+        return argparse
 
     def _start(self):
         self._session = requests.session()

--- a/cytomine/cytomine.py
+++ b/cytomine/cytomine.py
@@ -50,7 +50,7 @@ class Cytomine(object):
     __instance = None
 
     def __init__(self, host, public_key, private_key, verbose=None, use_cache=True, protocol="http",
-                 logging_handlers=[StdoutHandler()], working_path="/tmp", **kwargs):
+                 logging_handlers=None, working_path="/tmp", **kwargs):
         """
         Initialize the Cytomine Python client which is a singleton.
 
@@ -103,6 +103,7 @@ class Cytomine(object):
             requests_log = logging.getLogger("requests.packages.urllib3")
             requests_log.setLevel(logging.DEBUG)
             requests_log.propagate = True
+            logging_handlers = logging_handlers if logging_handlers is not None else [StdoutHandler()]
             for handler in logging_handlers:
                 requests_log.addHandler(handler)
 

--- a/cytomine/cytomine.py
+++ b/cytomine/cytomine.py
@@ -48,6 +48,40 @@ from cytomine.utilities.version import deprecated
 from cytomine.utilities.logging import StdoutHandler
 
 
+def _cytomine_parameter_name_synonyms(name, prefix="--"):
+    """For a given parameter name, returns all the possible usual synonym (and the parameter itself). Optionally, the
+    function can prepend a string to the found names.
+
+    If a parameters has no known synonyms, the function returns only the prefixed $name.
+
+    Parameters
+    ----------
+    name: str
+        Parameter based on which synonyms must searched for
+    prefix: str
+        The prefix
+
+    Returns
+    -------
+    names: str
+        List of prefixed parameter names containing at least $name (preprended with $prefix).
+    """
+    synonyms = [
+        ["host", "cytomine_host"],
+        ["public_key", "publicKey", "cytomine_public_key"],
+        ["private_key", "privateKey", "cytomine_private_key"],
+        ["base_path", "basePath", "cytomine_base_path"],
+        ["id_software", "cytomine_software_id", "cytomine_id_software", "idSoftware", "software_id"],
+        ["id_project", "cytomine_project_id", "cytomine_id_project", "idProject", "project_id"]
+    ]
+    synonyms_dict = {params[i]: params[:i] + params[(i + 1):] for params in synonyms for i in range(len(params))}
+
+    if name not in synonyms_dict:
+        return [prefix + name]
+
+    return [prefix + n for n in ([name] + synonyms_dict[name])]
+
+
 class Cytomine(object):
     __instance = None
 
@@ -181,11 +215,11 @@ class Cytomine(object):
         argparse: ArgumentParser
             The argument parser (same object as parameter)
         """
-        argparse.add_argument("--host", "--cytomine_host",
+        argparse.add_argument(*_cytomine_parameter_name_synonyms("host"),
                               dest="host", help="The Cytomine host (without protocol).", required=True)
-        argparse.add_argument("--publicKey", "--cytomine_public_key",
+        argparse.add_argument(*_cytomine_parameter_name_synonyms("public_key"),
                               dest="public_key", help="The Cytomine public key.", required=True)
-        argparse.add_argument("--privateKey", "--cytomine_private_key",
+        argparse.add_argument(*_cytomine_parameter_name_synonyms("private_key"),
                               dest="private_key", help="The Cytomine private key.", required=True)
         argparse.add_argument("--verbose", "--cytomine_verbose",
                               dest="verbose", type=int, default=logging.INFO, help="The verbosity level of the client.")

--- a/cytomine/cytomine.py
+++ b/cytomine/cytomine.py
@@ -91,6 +91,7 @@ class Cytomine(object):
         self._verbose = verbose
         self._logger.setLevel(verbose)
 
+        logging_handlers = logging_handlers if logging_handlers is not None else [StdoutHandler()]
         for handler in logging_handlers:
             self._logger.addHandler(handler)
 
@@ -105,7 +106,6 @@ class Cytomine(object):
             requests_log = logging.getLogger("requests.packages.urllib3")
             requests_log.setLevel(logging.DEBUG)
             requests_log.propagate = True
-            logging_handlers = logging_handlers if logging_handlers is not None else [StdoutHandler()]
             for handler in logging_handlers:
                 requests_log.addHandler(handler)
 
@@ -181,9 +181,9 @@ class Cytomine(object):
         argparse: ArgumentParser
             The argument parser (same object as parameter)
         """
-        argparse.add_argument("--cytomine_host", dest="host", help="The Cytomine host (without protocol).")
-        argparse.add_argument("--cytomine_public_key", dest="public_key", help="The Cytomine public key.")
-        argparse.add_argument("--cytomine_private_key", dest="private_key", help="The Cytomine private key.")
+        argparse.add_argument("--cytomine_host", dest="host", help="The Cytomine host (without protocol).", required=True)
+        argparse.add_argument("--cytomine_public_key", dest="public_key", help="The Cytomine public key.", required=True)
+        argparse.add_argument("--cytomine_private_key", dest="private_key", help="The Cytomine private key.", required=True)
         argparse.add_argument("--cytomine_verbose", dest="verbose", type=int, default=logging.INFO,
                               help="The verbosity level of the client.")
         return argparse

--- a/cytomine/cytomine_job.py
+++ b/cytomine/cytomine_job.py
@@ -168,9 +168,7 @@ class CytomineJob(Cytomine):
             filters={"software": cytomine_job.software.id},
             withSetByServer=True
         ).fetch()
-        soft_params, _ = _software_params_to_argparse(params_collection).parse_known_args(argv)
-        cytomine_job.parameters = soft_params
-
+        cytomine_job.parameters, _ = _software_params_to_argparse(params_collection).parse_known_args(argv)
         return cytomine_job
 
     @property

--- a/cytomine/cytomine_job.py
+++ b/cytomine/cytomine_job.py
@@ -168,7 +168,6 @@ class CytomineJob(Cytomine):
             filters={"software": cytomine_job.software.id},
             withSetByServer=True
         ).fetch()
-        parameters = cls._add_cytomine_cli_args(_software_params_to_argparse(params_collection))
         soft_params, _ = _software_params_to_argparse(params_collection).parse_known_args(argv)
         cytomine_job.parameters = soft_params
 

--- a/cytomine/cytomine_job.py
+++ b/cytomine/cytomine_job.py
@@ -122,8 +122,8 @@ class CytomineJob(Cytomine):
         The identifier of the software on the Cytomine server
     project_id : int
         The identifier of the project to process on the Cytomine server
-    parameters: dict
-        A dictionary mapping job parameters with their values (the dictionary must not contain any other key than
+    parameters: Namespace
+        A namespace mapping job parameters with their values (must not contain any other key than
         the parameters names)
     """
     def __init__(self, host, public_key, private_key, software_id, project_id, parameters=None, **kwargs):
@@ -155,7 +155,7 @@ class CytomineJob(Cytomine):
         # Parse and set job parameters
         params_collection = SoftwareParameterCollection(filters={"software": cytomine_job.software.id}).fetch()
         soft_params, _ = _software_params_to_argparse(params_collection).parse_known_args(argv)
-        cytomine_job.parameters = vars(soft_params)
+        cytomine_job.parameters = soft_params
 
         return cytomine_job
 
@@ -257,10 +257,11 @@ class CytomineJob(Cytomine):
 
         # add software parameters
         if self._parameters is not None:
+            parameters = vars(self._parameters)
             for software_param in self._software.parameters:
                 name = software_param["name"]
-                if name in self._parameters:
-                    value = self._parameters[name]
+                if name in parameters:
+                    value = parameters[name]
                 else:
                     value = software_param["defaultParamValue"]
 

--- a/cytomine/cytomine_job.py
+++ b/cytomine/cytomine_job.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 
 from argparse import ArgumentParser
 
-from cytomine.cytomine import Cytomine
+from cytomine.cytomine import Cytomine, _cytomine_parameter_name_synonyms
 from cytomine.models.project import Project
 from cytomine.models.software import Software, Job, JobParameter, SoftwareParameterCollection
 from cytomine.models.user import User
@@ -89,15 +89,6 @@ def _software_params_to_argparse(parameters):
     argparse: ArgumentParser
         An initialized argument parser
     """
-    # define special parameters, maps a possible parameters name with its synonym
-    special_param_names = {
-        "host": "cytomine_host",
-        "publicKey": "cytomine_public_key",
-        "privateKey": "cytomine_private_key",
-        "cytomine_host": "host",
-        "cytomine_public_key": "publicKey",
-        "cytomine_private_key": "privateKey"
-    }
     # Check software parameters
     argparse = ArgumentParser()
     boolean_defaults = {}
@@ -111,10 +102,7 @@ def _software_params_to_argparse(parameters):
             python_type = _convert_type(parameter.type)
             arg_desc["type"] = python_type
             arg_desc["default"] = None if parameter.defaultParamValue is None else python_type(parameter.defaultParamValue)
-        names = [parameter.name]
-        if parameter.name in special_param_names:
-            names.append(special_param_names[parameter.name])
-        argparse.add_argument(*["--{}".format(name) for name in names], **arg_desc)
+        argparse.add_argument(*_cytomine_parameter_name_synonyms(parameter.name), **arg_desc)
     argparse.set_defaults(**boolean_defaults)
     return argparse
 
@@ -159,9 +147,9 @@ class CytomineJob(Cytomine):
     def from_cli(cls, argv, **kwargs):
         # Parse CytomineJob constructor parameters
         argparse = cls._add_cytomine_cli_args(ArgumentParser())
-        argparse.add_argument("--cytomine_id_software",
+        argparse.add_argument(*_cytomine_parameter_name_synonyms("software_id"),
                               dest="software_id", type=int, help="The Cytomine software id.", required=True)
-        argparse.add_argument("--cytomine_id_project",
+        argparse.add_argument(*_cytomine_parameter_name_synonyms("project_id"),
                               dest="project_id", type=int, help="The Cytomine project id.", required=True)
         base_params, _ = argparse.parse_known_args(args=argv)
 

--- a/cytomine/cytomine_job.py
+++ b/cytomine/cytomine_job.py
@@ -19,14 +19,83 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from argparse import ArgumentParser
+
 from cytomine.cytomine import Cytomine
 from cytomine.models.project import Project
-from cytomine.models.software import Software, Job, JobParameter
+from cytomine.models.software import Software, Job, JobParameter, SoftwareParameterCollection
 from cytomine.models.user import User
 
 __author__ = "Begon Jean-Michel <jm.begon@gmail.com>"
 __contributors = ["Mormont Romain <romainmormont@gmail.com", "Rubens Ulysse <urubens@uliege.be>"]
 __copyright__ = "Copyright 2010-2018 University of Liège, Belgium, http://www.cytomine.be/"
+
+
+def _convert_type(_type):
+    # Not trying too hard for the finding types (list considered as string and number as floats)
+    # Just want a first validation (when possible) with argparse.
+    # Advanced checking is advised in actual job implementation.
+    return {
+        "Number": float,
+        "String": str,
+        "Boolean": bool,
+        "Domain": int,
+        "List": str,
+        "ListDomain": str,
+        "Date": str
+    }[_type]
+
+
+def _to_bool(v):
+    """
+    Convert the value to boolean. Treat the following strings
+    as False: {"0", "0.0", "False", "false", "FALSE"}
+
+    Parameters
+    ----------
+    v: object
+        A object to convert to a boolean value.
+
+    Returns
+    -------
+    b: bool
+        The boolean value
+    """
+    if isinstance(v, str):
+        return v in {"0", "0.0", "False", "false", "FALSE"}
+    else:
+        return bool(v)
+
+
+def _software_params_to_argparse(parameters):
+    """
+    Converts a SoftwareParameterCollection into an ArgumentParser object.
+
+    Parameters
+    ----------
+    parameters: SoftwareParameterCollection
+        The software parameters
+    Returns
+    -------
+    argparse: ArgumentParser
+        An initialized argument parser
+    """
+    # Check software parameters
+    argparse = ArgumentParser()
+    boolean_defaults = {}
+    for parameter in parameters:
+        arg_desc = {"dest": parameter.name, "required": parameter.required, "help": ""}  # TODO add help
+        if parameter.type == "Boolean":
+            default = _to_bool(parameter.defaultParamValue)
+            arg_desc["action"] = "store_true" if not default else "store_false"
+            boolean_defaults[parameter.name] = default
+        else:
+            python_type = _convert_type(parameter.type)
+            arg_desc["type"] = python_type
+            arg_desc["default"] = None if parameter.defaultParamValue is None else python_type(parameter.defaultParamValue)
+        argparse.add_argument("--{}".format(parameter.name), **arg_desc)
+    argparse.set_defaults(**boolean_defaults)
+    return argparse
 
 
 class CytomineJob(Cytomine):
@@ -65,6 +134,31 @@ class CytomineJob(Cytomine):
         self._job_done = False
         self._parameters = parameters
 
+    @classmethod
+    def from_cli(cls, argv, **kwargs):
+        # Parse CytomineJob constructor parameters
+        argparse = cls._add_cytomine_cli_args(ArgumentParser())
+        argparse.add_argument("--cytomine_software_id", dest="software_id", type=int, help="The Cytomine software id.", required=True)
+        argparse.add_argument("--cytomine_project_id", dest="project_id", type=int, help="The Cytomine project id.", required=True)
+        base_params, _ = argparse.parse_known_args(args=argv)
+
+        cytomine_job = CytomineJob(
+            host=base_params.host,
+            public_key=base_params.public_key,
+            private_key=base_params.private_key,
+            software_id=base_params.software_id,
+            project_id=base_params.project_id,
+            parameters=None,
+            **kwargs
+        )
+
+        # Parse and set job parameters
+        params_collection = SoftwareParameterCollection(filters={"software": cytomine_job.software.id}).fetch()
+        soft_params, _ = _software_params_to_argparse(params_collection).parse_known_args(argv)
+        cytomine_job.parameters = vars(soft_params)
+
+        return cytomine_job
+
     @property
     def job(self):
         """Return the job model
@@ -99,6 +193,28 @@ class CytomineJob(Cytomine):
             The id of the software
         """
         return self._software
+
+    @property
+    def parameters(self):
+        """
+        Return
+        ------
+        parameters : dict
+            The id of the software
+        """
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """
+        Protected method.
+
+        Parameters
+        ----------
+        parameters: dict
+            Dictionnary mapping parameters name with their values.
+        """
+        self._parameters = parameters
 
     def done(self, status=True):
         """


### PR DESCRIPTION
Cytomine and CytomineJob can be constructed from command line interface parameters. 

Cytomine CLI parameters (through `Cytomine.connect_from_cli` class method):
- `cytomine_host`
- `cytomine_public_key`
- `cytomine_private_key`
- `cytomine_verbose` (optional)

CytomineJob CLI parameters (through `CytomineJob.from_cli` class method):
- same as for Cytomine
- `cytomine_software_id`
- `cytomine_project_id`
- \+ any relevant job parameters

Job parameters are validated using parameters information fetched from the server. They can be accessed with the syntax: `job.parameters.PARAM_NAME`

Possible improvements:
- Regarding the types, the validation is shallow. It is due to the fact that we don't have enough information in a JobParameter for doing a more thourough check. For instance, a consequence is that integer parameters will be converted to float during the parsing. Also, more complex types (e.g. List, ListDomain) are not validated at all (considered as string). 
- I had to add a setter for the 'parameters' property in CytomineJob (because I cannot set the validated job parameters during the CytomineJob construction, so I have to do it after). 
- No help field in the DB yet so it is initialized with an empty string for now (see TODO in CytomineJob)

@urubens  @elodieburtin