### PR TITLE
Simplify job logging and loop progress monitoring 

### DIFF
--- a/cytomine/__init__.py
+++ b/cytomine/__init__.py
@@ -19,4 +19,4 @@ __contributors__ = ["Marée Raphaël <raphael.maree@uliege.be>", "Mormont Romain
 __copyright__ = "Copyright 2010-2018 University of Liège, Belgium, http://www.cytomine.be/"
 
 from .cytomine import Cytomine
-from .cytomine_job import CytomineJob
+from .cytomine_job import CytomineJob, CytomineJobLogger, CytomineJobProgressMonitor

--- a/cytomine/cytomine_job.py
+++ b/cytomine/cytomine_job.py
@@ -302,34 +302,35 @@ class CytomineJob(Cytomine):
         self.close()
         return False
 
-    def logger(self, start=0, end=100, update_period=None):
+    def logger(self, start=0, end=100, period=None):
         """Return a logger for the current job."""
-        return CytomineJobLogger(self, progress_start=start, progress_end=end, update_period=update_period)
+        return CytomineJobLogger(self, start=start, end=end, period=period)
 
-    def monitor(self, iterable, start=0, end=100, update_period=None, prefix=""):
+    def monitor(self, iterable, start=0, end=100, period=None, prefix=""):
         """Return a monitor for the current job"""
-        return self.logger(start=start, end=end, update_period=update_period).monitor(iterable, prefix=prefix)
+        return self.logger(start=start, end=end, period=period).monitor(iterable, prefix=prefix)
 
 
 class CytomineJobLogger(object):
-    def __init__(self, cytomine_job: CytomineJob, progress_start=0, progress_end=100, update_period=None):
+    def __init__(self, cytomine_job: CytomineJob, start=0, end=100, period=None):
         """A logger serves as intermediary between the job implementation and the job status update requests.
 
         Parameters
         ----------
         cytomine_job: CytomineJob
             The job
-        progress_start: float (range: [0.0, 100.0[)
+        start: float (range: [0.0, 100.0[)
             Progress at which the logger should start
-        progress_end: float (range: ]0.0, 100.0])
+        end: float (range: ]0.0, 100.0])
             Progress at which the logger should stop
-        update_period: int, float
-            The number of iteration to wait before actually updating the status. For for updating at each iteration
+        period: int, float
+            The number of iteration to wait before actually updating the status. Also supports
+            frequencies (float values).
         """
         self._cytomine_job = cytomine_job
-        self._start = progress_start
-        self._end = progress_end
-        self._update_period = update_period
+        self._start = start
+        self._end = end
+        self._update_period = period
 
     def update(self, statusComment, current, total, status=Job.RUNNING):
         """
@@ -365,9 +366,9 @@ class CytomineJobLogger(object):
         """Return a logger that updates progress in a subrange of the current logger's range."""
         return CytomineJobLogger(
             self._cytomine_job,
-            progress_start=self._relative_progress(progress_start / 100.),
-            progress_end=self._relative_progress(progress_end / 100.),
-            update_period=update_period
+            start=self._relative_progress(progress_start / 100.),
+            end=self._relative_progress(progress_end / 100.),
+            period=update_period
         )
 
     def monitor(self, iterable, prefix=""):


### PR DESCRIPTION
Basically adds two new classes: `CytomineJobLogger` and `CytomineJobProgressMonitor`

Example usage:

```python
with CytomineJob.from_cli(argv) as cj:
    cj.job.update(statusComment="Fetch crops of annotations.", progress=10)
    x = np.zeros([n_samples], dtype=np.object)
    for i, annotation in cj.monitor(enumerate(annotations), start=10, end=40, prefix="Fetch crops", period=0.1):
        file_format = os.path.join(data_path, str(annotation.term[0]), "{id}.png")
        if not annotation.dump(dest_pattern=file_format):
            raise ValueError("Download error for annotation '{}'.".format(annotation.id))
        x[i] = file_format.format(id=annotation.id)
```

Running this loop will send 10 job status update requests to the core notifying a progress update starting at 10% to 40%. A status comment will also be sent and will inform on the progress of the loop (e.g.: "Fetch crops (106/1053)"). Those responsibilities are handled by the `CytomineJobProgressMonitor` class.

The update can also be sent more manually by directly using the class `CytomineJobLogger`:

```python
with CytomineJob.from_cli(argv) as cj:
    cj.job.update(statusComment="Fetch crops of annotations.", progress=10)
    x = np.zeros([n_samples], dtype=np.object)
    download_logger = cj.logger(start=10, end=40, period=0.1)
    for i, annotation in enumerate(annotations):
        file_format = os.path.join(data_path, str(annotation.term[0]), "{id}.png")
        if not annotation.dump(dest_pattern=file_format):
            raise ValueError("Download error for annotation '{}'.".format(annotation.id))
        x[i] = file_format.format(id=annotation.id)
        download_logger.update(
            statusComment="Fetch crops ({}/{}).".format(i + 1, n_samples),
            current=i, total=n_samples
        )
```
