### PR TITLE
Rework annotation crop download

### DIFF
--- a/cytomine/models/annotation.py
+++ b/cytomine/models/annotation.py
@@ -251,23 +251,28 @@ class AnnotationCollection(Collection):
         else:
             raise ValueError("Invalid value '{}' for chunk parameter.".format(chunk))
 
-    def download_annotation_crops(self, n_workers=0, **dump_params):
-        """Download the crops of the given annotations
+    def dump_crops(self, dest_pattern, n_workers=0, override=True, **dump_params):
+        """Download the crops of the annotations
         Parameters
         ----------
+        dest_pattern : str, optional
+            Destination path for the downloaded image. "{X}" patterns are replaced by the value of X attribute
+            if it exists.
+        override : bool, optional
+            True if a file with same name can be overrided by the new file.
         n_workers: int
             Number of workers to use (default: uses all the available processors)
         dump_params: dict
-            Parameters for dumping the annotations
+            Parameters for dumping the annotations (see Annotation.dump)
 
         Returns
         -------
         annotations: AnnotationCollection
-            List of annotations (containing a `filenames` attribute)
+            Annotations that have been successfully downloaded (containing a `filenames` attribute)
         """
 
         def dump_crop(an):
-            if is_false(an.dump(**dump_params)):
+            if is_false(an.dump(dest_pattern=dest_pattern, override=override, **dump_params)):
                 return False
             else:
                 return an
@@ -290,7 +295,6 @@ class AnnotationCollection(Collection):
                 "Failed to download crops for {}/{} annotations ({:3.2f} %).".format(count_fail, n_annots, ratio))
             logger.debug("Annotation with crop download failure: {}".format(failed))
 
-        from cytomine.models import AnnotationCollection  # to avoid circular import
         collection = AnnotationCollection()
         collection.extend([an for _, an in results if not isinstance(an, bool) or an])
         return collection

--- a/cytomine/models/util.py
+++ b/cytomine/models/util.py
@@ -1,0 +1,49 @@
+import re
+from copy import copy
+
+
+def is_iterable(obj):
+    """Portable way to check that an object is iterable"""
+    try:
+        iter(obj)
+        return True
+    except TypeError:
+        return False
+
+
+def resolve_pattern(pattern, attr_source):
+    """Resolve a string pattern using values from an attribute source. If one attribute is an iterable (and not a
+    string) the pattern will be resolved once for each value in the iterable.
+
+    Parameters
+    ----------
+    pattern: str
+        A string pattern such as '{placeholder1}/___aa__{placeholder2).stg'.
+    attr_source: object
+        An object with attributes matching the names of the placeholders in the patterns.
+
+    Returns
+    -------
+    resolved: iterable
+        The list of resolved patterns
+    """
+    matches = re.findall("{([^\}]+)}", pattern)
+    attr_dict = {match: getattr(attr_source, match, "_") for match in matches}
+
+    # remaining attributes to fill in the pattern
+    remaining = set(attr_dict.keys())
+    patterns = [pattern]
+    for attr, values in attr_dict.items():
+        remaining.remove(attr)
+        resolved = list()
+        if isinstance(values, str) or not is_iterable(values):
+            values = [values]
+        format_params = {a: "{" + a + "}" for a in remaining}
+        for v in values:
+            for p in patterns:
+                format_params = copy(format_params)
+                format_params[attr] = v
+                resolved.append(p.format(**format_params))
+        patterns = resolved
+
+    return patterns

--- a/cytomine/tests/test_pattern_matching.py
+++ b/cytomine/tests/test_pattern_matching.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+
+from cytomine.utilities.pattern_matching import resolve_pattern
+
+
+class TestPatternMatching:
+    def get_fake_type(self):
+        return namedtuple("fakeobj", ["lst", "atomstr", "atomfloat"])
+
+    def test_no_iterable_pattern(self):
+        fake = self.get_fake_type()(lst=1, atomstr="aa", atomfloat=1.5)
+        resolved = sorted(resolve_pattern("{lst}/{atomstr}_{atomfloat}.png", fake))
+        assert(len(resolved) == 1)
+        assert(resolved[0] == "1/aa_1.5.png")
+
+    def test_single_iterable_pattern(self):
+        fake = self.get_fake_type()(lst=[1, 2, 3], atomstr="aa", atomfloat=1.5)
+        resolved = sorted(resolve_pattern("{lst}/{atomstr}_{atomfloat}.png", fake))
+        assert(len(resolved) == 3)
+        assert(resolved[0] == "1/aa_1.5.png")
+        assert(resolved[1] == "2/aa_1.5.png")
+        assert(resolved[2] == "3/aa_1.5.png")
+
+    def test_no_placeholder(self):
+        fake = self.get_fake_type()(lst=[1, 2, 3], atomstr="aa", atomfloat=1.5)
+        resolved = resolve_pattern("no_placeholder", fake)
+        assert(len(resolved) == 0)

--- a/cytomine/utilities/__init__.py
+++ b/cytomine/utilities/__init__.py
@@ -22,3 +22,4 @@ from .geometry import *
 from .logging import *
 from .reader import *
 from .wholeslide import *
+from .download_util import download_annotation_crops

--- a/cytomine/utilities/__init__.py
+++ b/cytomine/utilities/__init__.py
@@ -22,4 +22,5 @@ from .geometry import *
 from .logging import *
 from .reader import *
 from .wholeslide import *
-from .download_util import download_annotation_crops
+from .download_util import *
+from .pattern_matching import *

--- a/cytomine/utilities/download_util.py
+++ b/cytomine/utilities/download_util.py
@@ -1,26 +1,8 @@
 import errno
 import os
 from queue import Queue
-from shutil import copyfile
 from threading import Thread
 from multiprocessing import cpu_count
-
-from cytomine.utilities.pattern_matching import resolve_pattern
-
-from cytomine import Cytomine
-
-
-class DumpError(Exception):
-    pass
-
-
-def makedirs(path, exist_ok=True):
-    """Python 2.7 compatinle"""
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if not (exist_ok and e.errno == errno.EEXIST):
-            raise  # Reraise if failed for reasons other than existing already
 
 
 def is_false(v):
@@ -88,104 +70,13 @@ def generic_download(data, download_instance_fn, n_workers=0):
     return results
 
 
-def generic_image_dump(dest_pattern, model, url_fn, override=True, **parameters):
-    """A generic function for 'dumping' a model as an image (crop, windows,...).
-    Parameters
-    ----------
-    dest_pattern: str
-        The destination pattern for the image.
-    model: Model
-        A Cytomine model
-    url_fn: callable
-        A function for generating the url of the image. The function call would be like the following:
-            url_fn(model, file_path, **parameters)
-        where model is the cytomine model, file_path is the destination filepath and paramters are the dump
-        parameters.
-    override: bool
-        True for overriding the file. False
-    parameters: dict
-
-    Returns
-    -------
-    downloaded: iterable
-        The list of downloaded files
-
-    Raises
-    ------
-    DumpError:
-        When the download fails.
-    """
-    # generate download path(s)
-    files_to_download = list()
-    for file_path in resolve_pattern(dest_pattern, model):
-        destination = os.path.dirname(file_path)
-        filename, extension = os.path.splitext(os.path.basename(file_path))
-        extension = extension[1:]
-
-        if extension not in ("jpg", "png", "tif", "tiff"):
-            extension = "jpg"
-
-        makedirs(destination, exist_ok=True)
-
-        files_to_download.append(os.path.join(destination, "{}.{}".format(filename, extension)))
-
-    if len(files_to_download) == 0:
-        raise ValueError("Couldn't generate a dump path.")
-
-    # download once
-    file_path = files_to_download[0]
-    url = url_fn(model, file_path, **parameters)
-    if not Cytomine.get_instance().download_file(url, file_path, override, parameters):
-        raise DumpError("Could not dump the image.")
-
-    # copy the file to the other paths (if any)
-    for dest_file_path in files_to_download[1:]:
-        if override or not os.path.isfile(dest_file_path):
-            copyfile(file_path, dest_file_path)
-
-    return files_to_download
+def makedirs(path, exist_ok=True):
+    """Python 2.7 compatinle"""
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if not (exist_ok and e.errno == errno.EEXIST):
+            raise  # Reraise if failed for reasons other than existing already
 
 
-def download_annotation_crops(annotations, n_workers=0, **dump_params):
-    """Download the crops of the given annotations
-    Parameters
-    ----------
-    annotations: AnnotationCollection
-        The annotations of which the crops should be downloaded
-    n_workers: int
-        Number of workers to use (default: uses all the available processors)
-    dump_params: dict
-        Parameters for dumping the annotations
 
-    Returns
-    -------
-    annotations: AnnotationCollection
-        List of annotations (containing a `filenames` attribute)
-    """
-    def dump_crop(an):
-        if is_false(an.dump(**dump_params)):
-            return False
-        else:
-            return an
-
-    results = generic_download(annotations, download_instance_fn=dump_crop, n_workers=n_workers)
-
-    # check errors
-    count_fail = 0
-    failed = list()
-    for in_annot, out_annot in results:
-        if is_false(out_annot):
-            count_fail += 1
-            failed.append(in_annot.id)
-
-    logger = Cytomine.get_instance().logger
-    if count_fail > 0:
-        n_annots = len(annotations)
-        ratio = 100 * count_fail / float(n_annots)
-        logger.info("Failed to download crops for {}/{} annotations ({:3.2f} %).".format(count_fail, n_annots, ratio))
-        logger.debug("Annotation with crop download failure: {}".format(failed))
-
-    from cytomine.models import AnnotationCollection  # to avoid circular import
-    collection = AnnotationCollection()
-    collection.extend([an for _, an in results if not isinstance(an, bool) or an])
-    return collection

--- a/cytomine/utilities/download_util.py
+++ b/cytomine/utilities/download_util.py
@@ -1,10 +1,17 @@
 import errno
 import os
 from queue import Queue
+from shutil import copyfile
 from threading import Thread
 from multiprocessing import cpu_count
 
+from cytomine.utilities.pattern_matching import resolve_pattern
+
 from cytomine import Cytomine
+
+
+class DumpError(Exception):
+    pass
 
 
 def makedirs(path, exist_ok=True):
@@ -79,6 +86,64 @@ def generic_download(data, download_instance_fn, n_workers=0):
         results.append(out_queue.get_nowait())
 
     return results
+
+
+def generic_image_dump(dest_pattern, model, url_fn, override=True, **parameters):
+    """A generic function for 'dumping' a model as an image (crop, windows,...).
+    Parameters
+    ----------
+    dest_pattern: str
+        The destination pattern for the image.
+    model: Model
+        A Cytomine model
+    url_fn: callable
+        A function for generating the url of the image. The function call would be like the following:
+            url_fn(model, file_path, **parameters)
+        where model is the cytomine model, file_path is the destination filepath and paramters are the dump
+        parameters.
+    override: bool
+        True for overriding the file. False
+    parameters: dict
+
+    Returns
+    -------
+    downloaded: iterable
+        The list of downloaded files
+
+    Raises
+    ------
+    DumpError:
+        When the download fails.
+    """
+    # generate download path(s)
+    files_to_download = list()
+    for file_path in resolve_pattern(dest_pattern, model):
+        destination = os.path.dirname(file_path)
+        filename, extension = os.path.splitext(os.path.basename(file_path))
+        extension = extension[1:]
+
+        if extension not in ("jpg", "png", "tif", "tiff"):
+            extension = "jpg"
+
+        makedirs(destination, exist_ok=True)
+
+        files_to_download.append(os.path.join(destination, "{}.{}".format(filename, extension)))
+
+    if len(files_to_download) == 0:
+        raise ValueError("Couldn't generate a dump path.")
+
+    # download once
+    file_path = files_to_download[0]
+    url = url_fn(model, file_path, **parameters)
+    if not Cytomine.get_instance().download_file(url, file_path, override, parameters):
+        raise DumpError("Could not dump the image.")
+
+    # copy the file to the other paths (if any)
+    for dest_file_path in files_to_download[1:]:
+        if override or not os.path.isfile(dest_file_path):
+            copyfile(file_path, dest_file_path)
+
+    return files_to_download
 
 
 def download_annotation_crops(annotations, n_workers=0, **dump_params):

--- a/cytomine/utilities/parallel_download.py
+++ b/cytomine/utilities/parallel_download.py
@@ -1,0 +1,126 @@
+import errno
+import os
+from queue import Queue
+from threading import Thread
+from multiprocessing import cpu_count
+
+from cytomine import Cytomine
+
+
+def makedirs(path, exist_ok=True):
+    """Python 2.7 compatinle"""
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if not (exist_ok and e.errno == errno.EEXIST):
+            raise  # Reraise if failed for reasons other than existing already
+
+
+def is_false(v):
+    """Check if v is 'False'"""
+    return isinstance(v, bool) and not v
+
+
+def generic_download(data, download_instance_fn, n_workers=0):
+    """Download a set of data in parallel using a given download function.
+
+    Parameters
+    ----------
+    data: iterable
+        The data to be downloaded with `download_instance_fn`
+    download_instance_fn: callable
+        A functions that downloads what needs to be downloaded. It has one parameter which must be the same type as the
+        items of `data`. If needed it can return a value.
+    n_workers: int
+        Number of workers to use (default: uses all the available processors)
+
+    Returns
+    -------
+    results: iterable
+        List processed items as tuples. First element of the tuple is the item itself, the second element of the tuple
+        is the value returned by `download_instance_fn` for this item.
+    """
+    def worker(_in, _out):
+        while True:
+            item = _in.get()
+            if item is None:
+                break
+            _out.put((item, download_instance_fn(item)))
+
+    if n_workers <= 0:
+        n_workers = cpu_count()
+    else:
+        n_workers = n_workers
+
+    # instantiate multiprocessing objects
+    in_queue = Queue()
+    out_queue = Queue()
+    threads = [Thread(target=worker, args=[in_queue, out_queue]) for _ in range(n_workers)]
+
+    for t in threads:
+        t.daemon = True
+        t.start()
+
+    for item in data:
+        if item is None:
+            continue
+        in_queue.put(item)
+
+    # feed `n_workers` None values in the queue to stop the workers
+    for _ in range(n_workers):
+        in_queue.put(None)
+
+    # wait for the jobs to finish
+    for t in threads:
+        t.join()
+
+    results = list()
+    while not out_queue.empty():
+        results.append(out_queue.get_nowait())
+
+    return results
+
+
+def download_annotation_crops(annotations, n_workers=0, **dump_params):
+    """Download the crops of the given annotations
+    Parameters
+    ----------
+    annotations: AnnotationCollection
+        The annotations of which the crops should be downloaded
+    n_workers: int
+        Number of workers to use (default: uses all the available processors)
+    dump_params: dict
+        Parameters for dumping the annotations
+
+    Returns
+    -------
+    annotations: AnnotationCollection
+        List of annotations (containing a `filenames` attribute)
+    """
+    def dump_crop(an):
+        if is_false(an.dump(**dump_params)):
+            return False
+        else:
+            return an
+
+    results = generic_download(annotations, download_instance_fn=dump_crop, n_workers=n_workers)
+
+    # check errors
+    count_fail = 0
+    failed = list()
+    for in_annot, out_annot in results:
+        if is_false(out_annot):
+            count_fail += 1
+            failed.append(in_annot.id)
+
+    logger = Cytomine.get_instance().logger
+    if count_fail > 0:
+        n_annots = len(annotations)
+        ratio = 100 * count_fail / float(n_annots)
+        logger.info("Failed to download crops for {}/{} annotations ({:3.2f} %).".format(count_fail, n_annots, ratio))
+        logger.debug("Annotation with crop download failure: {}".format(failed))
+
+    from cytomine.models import AnnotationCollection  # to avoid circular import
+    collection = AnnotationCollection()
+    collection.extend([an for _, an in results if not isinstance(an, bool) or an])
+    return collection

--- a/cytomine/utilities/pattern_matching.py
+++ b/cytomine/utilities/pattern_matching.py
@@ -1,0 +1,49 @@
+import re
+from copy import copy
+
+
+def is_iterable(obj):
+    """Portable way to check that an object is iterable"""
+    try:
+        iter(obj)
+        return True
+    except TypeError:
+        return False
+
+
+def resolve_pattern(pattern, attr_source):
+    """Resolve a string pattern using values from an attribute source. If one attribute is an iterable (and not a
+    string) the pattern will be resolved once for each value in the iterable.
+
+    Parameters
+    ----------
+    pattern: str
+        A string pattern such as '{placeholder1}/___aa__{placeholder2).stg'.
+    attr_source: object
+        An object with attributes matching the names of the placeholders in the patterns.
+
+    Returns
+    -------
+    resolved: iterable
+        The list of resolved patterns
+    """
+    matches = re.findall("{([^\}]+)}", pattern)
+    attr_dict = {match: getattr(attr_source, match, "_") for match in matches}
+
+    # remaining attributes to fill in the pattern
+    remaining = set(attr_dict.keys())
+    patterns = [pattern]
+    for attr, values in attr_dict.items():
+        remaining.remove(attr)
+        resolved = list()
+        if isinstance(values, str) or not is_iterable(values):
+            values = [values]
+        format_params = {a: "{" + a + "}" for a in remaining}
+        for v in values:
+            for p in patterns:
+                format_params = copy(format_params)
+                format_params[attr] = v
+                resolved.append(p.format(**format_params))
+        patterns = resolved
+
+    return patterns

--- a/cytomine/utilities/pattern_matching.py
+++ b/cytomine/utilities/pattern_matching.py
@@ -1,8 +1,49 @@
-def main(argv):
-    pass
+import re
+from copy import copy
 
 
-if __name__ == "__main__":
-    import sys
+def is_iterable(obj):
+    """Portable way to check that an object is iterable"""
+    try:
+        iter(obj)
+        return True
+    except TypeError:
+        return False
 
-    main(sys.argv[1:])
+
+def resolve_pattern(pattern, attr_source):
+    """Resolve a string pattern using values from an attribute source. If one attribute is an iterable (and not a
+    string) the pattern will be resolved once for each value in the iterable.
+
+    Parameters
+    ----------
+    pattern: str
+        A string pattern such as '{placeholder1}/___aa__{placeholder2).stg'.
+    attr_source: object
+        An object with attributes matching the names of the placeholders in the patterns.
+
+    Returns
+    -------
+    resolved: iterable
+        The list of resolved patterns
+    """
+    matches = re.findall("{([^\}]+)}", pattern)
+    attr_dict = {match: getattr(attr_source, match, "_") for match in matches}
+
+    # remaining attributes to fill in the pattern
+    remaining = set(attr_dict.keys())
+    patterns = [pattern]
+    for attr, values in attr_dict.items():
+        remaining.remove(attr)
+        resolved = list()
+        if isinstance(values, str) or not is_iterable(values):
+            values = [values]
+        format_params = {a: "{" + a + "}" for a in remaining}
+        for v in values:
+            for p in patterns:
+                format_params = copy(format_params)
+                format_params[attr] = v
+                resolved.append(p.format(**format_params))
+        patterns = resolved
+
+    return patterns

--- a/cytomine/utilities/pattern_matching.py
+++ b/cytomine/utilities/pattern_matching.py
@@ -1,49 +1,8 @@
-import re
-from copy import copy
+def main(argv):
+    pass
 
 
-def is_iterable(obj):
-    """Portable way to check that an object is iterable"""
-    try:
-        iter(obj)
-        return True
-    except TypeError:
-        return False
+if __name__ == "__main__":
+    import sys
 
-
-def resolve_pattern(pattern, attr_source):
-    """Resolve a string pattern using values from an attribute source. If one attribute is an iterable (and not a
-    string) the pattern will be resolved once for each value in the iterable.
-
-    Parameters
-    ----------
-    pattern: str
-        A string pattern such as '{placeholder1}/___aa__{placeholder2).stg'.
-    attr_source: object
-        An object with attributes matching the names of the placeholders in the patterns.
-
-    Returns
-    -------
-    resolved: iterable
-        The list of resolved patterns
-    """
-    matches = re.findall("{([^\}]+)}", pattern)
-    attr_dict = {match: getattr(attr_source, match, "_") for match in matches}
-
-    # remaining attributes to fill in the pattern
-    remaining = set(attr_dict.keys())
-    patterns = [pattern]
-    for attr, values in attr_dict.items():
-        remaining.remove(attr)
-        resolved = list()
-        if isinstance(values, str) or not is_iterable(values):
-            values = [values]
-        format_params = {a: "{" + a + "}" for a in remaining}
-        for v in values:
-            for p in patterns:
-                format_params = copy(format_params)
-                format_params[attr] = v
-                resolved.append(p.format(**format_params))
-        patterns = resolved
-
-    return patterns
+    main(sys.argv[1:])


### PR DESCRIPTION
- rework dest_pattern logic to handle multi-value attributes
- create method `AnnotationCollection.dump_crops` for downloading all crops in an annotation collection (possibly in parallel)
- factorize dump annotations in generic dump function 


Not in this pull request: 
- implementation of `ImageInstance.window` and `ImageInstance.dump` using the generic dump function (ready but not tested)