### PR TITLE
add level 0 of the images in the WholeSlide object

### DIFF
--- a/cytomine/utilities/wholeslide.py
+++ b/cytomine/utilities/wholeslide.py
@@ -39,7 +39,7 @@ class WholeSlide(object):
         self.num_tiles = 0
         self.levels = []
 
-        for i in range(self.depth):
+        for i in range(self.depth + 1):
             level_width = int(self.width / 2 ** i)
             level_height = int(self.height / 2 ** i)
             x_tiles = int(math.ceil(float(level_width) / (float(tile_size))))


### PR DESCRIPTION
Hello, 

When I use the CytomineReader utility on a set of images, I'm unable to browse a small image with Reader utility as the read method crashes on small images (less than 256x256 pixels).

This is caused by an empty array for the zoom_levels of the WholeSlide images.

As the depth of an image instance is the max zoom level
https://github.com/Cytomine-ULiege/Cytomine-core/blob/master/grails-app/domain/be/cytomine/image/ImageInstance.groovy#L176
and the zoom level of a the related small images is 0
https://github.com/Cytomine-ULiege/Cytomine-core/blob/master/grails-app/domain/be/cytomine/image/AbstractImage.groovy#L267

This PR is a quick fix to consider the level 0 into this loop.

However, I can't predict all the side effects of this modification as you have a better view than me of all the processes with these methods.

If the level 0 was an omission, this is my PR.
If not, how will we fix the error for small images ?

Have a nice day.

Renaud