### PR TITLE
Update cytomine.py to close https request session

### DIFF
--- a/cytomine/cytomine.py
+++ b/cytomine/cytomine.py
@@ -354,7 +354,7 @@ class Cytomine(object):
         return self
 
     def __exit__(self, type, value, traceback):
-        pass
+        self._session.close()
 
     @staticmethod
     def get_instance():


### PR DESCRIPTION
Encountered warning:

python3.8/site-packages/cytomine/cytomine.py:346: ResourceWarning: unclosed <ssl.SSLSocket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('*IP*', 38488), raddr=(*IP*, 443)>
  Cytomine.__instance = self
ResourceWarning: Enable tracemalloc to get the object allocation traceback